### PR TITLE
Support base/head branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   branch:
     description: 'Branch name'
     required: true
+  base:
+    description: 'The base branch name of the Pull Request'
+    required: false
 outputs:
   number:
     description: The Pull Request's number if one was found (e.g. '345' for #345)

--- a/index.js
+++ b/index.js
@@ -6,13 +6,15 @@ const { GitHub, context } = require('@actions/github')
 const main = async () => {
   const token = core.getInput('github-token')
   const branch = core.getInput('branch')
+  const base = core.getInput('base', { required: false })
 
   const octokit = new GitHub(token)
 
   const res = await octokit.pulls.list({
     ...context.repo,
     state: 'open',
-    head: `${context.repo.owner}:${branch}`
+    head: `${context.repo.owner}:${branch}`,
+    base
   })
 
   const pr = res.data.length && res.data[0]


### PR DESCRIPTION
Hi @juliangruber, I wrote some codes that supports base branch and head branch. This resolves #8 because a pull request is unique if the base branch and the head branch are defined, I thought this is better than filtering by title.