### PR TITLE
The pull requests query is incorrect if one of the parameters is not given

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
   branch:
     description: 'Branch name'
-    required: true
+    required: false
   base:
     description: 'The base branch name of the Pull Request'
     required: false

--- a/index.js
+++ b/index.js
@@ -6,17 +6,22 @@ const { GitHub, context } = require('@actions/github')
 const main = async () => {
   const token = core.getInput('github-token')
   const branch = core.getInput('branch')
-  const base = core.getInput('base', { required: false })
+  const base = core.getInput('base')
+  
+  const query = {
+    ...context.repo,
+    state: 'open'
+  }
+  if (branch) {
+    query.head = `${context.repo.owner}:${branch}`
+  }
+  if (base) {
+    query.base = base
+  }
 
   const octokit = new GitHub(token)
 
-  const res = await octokit.pulls.list({
-    ...context.repo,
-    state: 'open',
-    head: `${context.repo.owner}:${branch}`,
-    base
-  })
-
+  const res = await octokit.pulls.list(query)
   const pr = res.data.length && res.data[0]
 
   core.debug(`pr: ${JSON.stringify(pr, null, 2)}`)


### PR DESCRIPTION
### Description

If either `branch` or `base` input parameter is not specified, the query that is used to retrieve pull requests is incorrect. 

### Steps to reproduce

Define `find-pull-request-action` with `base` parameter undefined:

```
- name: Find Pull Request
    uses: juliangruber/find-pull-request-action@v1.2.0
    id: find-pull-request
    with:
      github-token: ${{ secrets.GITHUB_TOKEN }}
      branch: my-branch-name
```

In that case, the action creates a query with an empty value for `base` query parameter. Such a query always returns no results.

```
https://api.github.com/repos/juliangruber/find-pull-request-action/pulls?state=open&head=juliangruber:my-branch-name&base=
```


