### PR TITLE
Ignore files created by JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# JavaScript
 node_modules
+
+# JetBrains IDE
+.idea/
+*.iml
+*.iws


### PR DESCRIPTION
Extend `.gitignore` to ignore different files created by JetBrains IDEs (IntelliJ IDEA, WebStorm etc.).