### PR TITLE
Support cross-repository branch reference

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,9 @@ inputs:
     description: 'GitHub Token'
     required: true
   branch:
-    description: 'Branch name'
+    description: |
+      The name of the branch from which the pull request was opened. For cross-repository pull requests namespace the
+      branch with user or organization name, i.e. 'user:branch-name' or 'org:branch-name'.
     required: false
   base:
     description: 'The base branch name of the Pull Request'

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const main = async () => {
     state: 'open'
   }
   if (branch) {
-    query.head = `${context.repo.owner}:${branch}`
+    query.head = branch.indexOf(':') === -1 ? `${context.repo.owner}:${branch}` : branch
   }
   if (base) {
     query.base = base


### PR DESCRIPTION
### Description

Currently, the action always namespace a branch name with a repository owner name (`repo-owner:branch-name`). Because of this, it's impossible to find a pull request created from a forked repository. This pull request changes this behaviour. The action will append the owner prefix only in the case branch name doesn't already have one (i.e. it doesn't contain `:`).