### PR TITLE
check pull request author

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   base:
     description: 'The base branch name of the Pull Request'
     required: false
+  author: 
+    description: 'The author of the Pull Request'
+    required: false
 outputs:
   number:
     description: The Pull Request's number if one was found (e.g. '345' for #345)

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const main = async () => {
 
   const res = await octokit.pulls.list(query)
   const pr = author ?
-    res.data.length && res.data[0].user.login === author && res.data[0] :
+    res.data.length && res.data.filter(pr => pr.user.login === author)[0] :
     res.data.length && res.data[0]
 
   core.debug(`pr: ${JSON.stringify(pr, null, 2)}`)

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const main = async () => {
   const token = core.getInput('github-token')
   const branch = core.getInput('branch')
   const base = core.getInput('base')
+  const author = core.getInput('author')
 
   const query = {
     ...context.repo,
@@ -23,7 +24,9 @@ const main = async () => {
   const octokit = new GitHub(token)
 
   const res = await octokit.pulls.list(query)
-  const pr = res.data.length && res.data[0]
+  const pr = author ?
+    res.data.length && res.data[0].user.login === author && res.data[0] :
+    res.data.length && res.data[0]
 
   core.debug(`pr: ${JSON.stringify(pr, null, 2)}`)
   core.setOutput('number', pr ? pr.number : '')


### PR DESCRIPTION
Hello 👋. I work on the GitHub docs team. We've recently run into an issue with open-source contributors that spurred this change. Currently, GitHub does not have a way to prevent external contributors from creating a pull request for a branch that originates from the base repository. This has become problematic for our open-source repo [github/docs](https://github.com/github/docs) that uses repo-sync. Some external contributors open pull requests when they see a new `repo-sync` branch created. Because we auto-approve pull requests, it's possible for external contributors to get attributed with changes from the repo-sync workflows. 

This pull request adds an input parameter `author`. The author is used to add the ability to only return pull requests creates by a specific author. 

@juliangruber please let us know if this change is out of scope. I've also requested a review from a team member @jamesmgreene.