### PR TITLE
feat: bump runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,5 +68,5 @@ outputs:
       A JSON string representing the array of pull request numbers matching the search criteria, e.g.: `[1,2,3]`
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary

GitHub is deprecating Node.js 20 from Actions runners (soft default switch: June 16, 2026, hard removal: September 16, 2026). After the hard removal date, workflows using this action will fail.

This PR bumps the runtime from \`node20\` to \`node24\` in \`action.yml\` and rebuilds \`dist/index.js\` via \`ncc build\`. No code changes - dependencies (\`@actions/core\`, \`@actions/github\`) are both compatible with Node.js 24.

## Changes
- \`action.yml\`: \`using: 'node20'\` → \`using: 'node24'\`
- \`dist/index.js\`: rebuilt with \`ncc\`

## Testing
- \`npm test\` (prettier-standard + standard linting) passes
- \`npm run build\` completes cleanly

## References
- Issue: https://github.com/juliangruber/find-pull-request-action/issues/57
- [GitHub announcement: Deprecating Node.js 20 in GitHub Actions](https://github.blog/changelog/2025-05-13-github-actions-deprecating-node-js-20-actions-and-runners/)